### PR TITLE
Update torrc.tmpl to use container names instead of IPs (fixes #3)

### DIFF
--- a/files/docker-gen/torrc.tmpl
+++ b/files/docker-gen/torrc.tmpl
@@ -12,13 +12,12 @@ HiddenServiceVersion 3
 {{ range $index, $value := $containers }}
 
 	{{ $addrLen := len $value.Addresses }}
-	{{ $network := index $value.Networks 0 }}
 	
 	{{/* If only 1 port exposed, use that */}}
 	{{ if eq $addrLen 1 }}
 		{{ with $address := index $value.Addresses 0 }}
 # auto: single port exposed
-HiddenServicePort {{ $address.Port }} {{ $network.IP }}:{{ $address.Port }}
+HiddenServicePort {{ $address.Port }} {{ $value.Name }}:{{ $address.Port }}
 		{{ end }}
 
 	{{/* If more than one port exposed, use the one matching VIRTUAL_PORT env var */}}
@@ -26,7 +25,7 @@ HiddenServicePort {{ $address.Port }} {{ $network.IP }}:{{ $address.Port }}
 		{{ range $i, $address := $value.Addresses }}
 			{{ if eq $address.Port $value.Env.ONIONSERVICE_PORT }}
 # port specified by ONIONSERVICE_PORT
-HiddenServicePort {{ $address.Port }} {{ $network.IP }}:{{ $address.Port }}
+HiddenServicePort {{ $address.Port }} {{ $value.Name }}:{{ $address.Port }}
 			{{ end }}
 		{{ end }}
 
@@ -35,7 +34,7 @@ HiddenServicePort {{ $address.Port }} {{ $network.IP }}:{{ $address.Port }}
 		{{ range $i, $address := $value.Addresses }}
 			{{ if eq $address.Port "80" }}
 # auto: standard port 80
-HiddenServicePort {{ $address.Port }} {{ $network.IP }}:{{ $address.Port }}
+HiddenServicePort {{ $address.Port }} {{ $value.Name }}:{{ $address.Port }}
 			{{ end }}
 		{{ end }}
 	{{ end }}


### PR DESCRIPTION
Change template according to #3 

Instead of `{{ $value.Name }}` one could also use `{{ $value.Hostname }}`

**Note**: I hope these changes are ok. A quick test with my example setup from #3 worked. But this is the first time I work with a `docker-gen` template. Please review.